### PR TITLE
Enable fake Cache::FileCache by removing `local`

### DIFF
--- a/t/XPathFeed.t
+++ b/t/XPathFeed.t
@@ -10,8 +10,8 @@ use XPathFeed;
 BEGIN {
     no strict 'refs';
     require Cache::FileCache;
-    local *Cache::FileCache::get = sub {};
-    local *Cache::FileCache::set = sub {};
+    *Cache::FileCache::get = sub {};
+    *Cache::FileCache::set = sub {};
 };
 
 sub _compile : Test(1) {


### PR DESCRIPTION
The fake definitions were only enabled in the `BEGIN` block due to `local`.
