### PR TITLE
Fix character corruption in /frame

### DIFF
--- a/lib/XPathFeed.pm
+++ b/lib/XPathFeed.pm
@@ -133,7 +133,7 @@ sub _res2result {
     my ($self, $res) = @_;
     return {
         content          => $res->content,
-        resolved_content => $self->_resolve($res->decoded_content),
+        resolved_content => $self->_resolve($res),
         decoded_content  => $res->decoded_content,
         cached           => time(),
     };
@@ -141,13 +141,9 @@ sub _res2result {
 
 sub _resolve {
     my $self = shift;
-    my $content = shift or return;
-    $content = $self->resolver->resolve($content);
-    if (Encode::is_utf8($content)) {
-        Encode::encode('utf-8', $content);
-    } else {
-        $content;
-    }
+    my $res = shift or return;
+    my $content = $self->resolver->resolve($res->decoded_content);
+    Encode::encode($res->content_charset, $content);
 }
 
 sub _add_inspector {

--- a/lib/XPathFeed.pm
+++ b/lib/XPathFeed.pm
@@ -142,9 +142,12 @@ sub _res2result {
 sub _resolve {
     my $self = shift;
     my $content = shift or return;
-    $content = Encode::encode('utf-8', $content) if Encode::is_utf8($content);
     $content = $self->resolver->resolve($content);
-    $content;
+    if (Encode::is_utf8($content)) {
+        Encode::encode('utf-8', $content);
+    } else {
+        $content;
+    }
 }
 
 sub _add_inspector {


### PR DESCRIPTION
- HTMLに`<input value="&#x2713;">`などの文字列が入っていると文字化けする
- 元のページの文字コードがUTF-8以外で、metaタグなどに元の文字コードの指定があると文字化けする

以上の2点の問題を修正するプルリクエストです。
