### PR TITLE
Ensure weak references in use in HTML::TreeBuilder?

### DIFF
--- a/lib/XPathFeed.pm
+++ b/lib/XPathFeed.pm
@@ -9,6 +9,7 @@ use Encode qw(decode_utf8);
 use HTML::ResolveLink;
 use HTML::Selector::XPath;
 use HTML::Tagset;
+use HTML::TreeBuilder 5 -weak;
 use HTML::TreeBuilder::XPath;
 use HTTP::Request;
 use Scalar::Util qw(blessed);
@@ -284,17 +285,6 @@ sub add_query_params {
         );
     }
     return $uri;
-}
-
-sub clean {
-    my $self = shift;
-    $self->tree or return;
-    $self->tree->delete;
-}
-
-sub DESTROY {
-    my $self = shift;
-    $self->clean;
 }
 
 # utility method

--- a/t/XPathFeed.t
+++ b/t/XPathFeed.t
@@ -89,8 +89,6 @@ sub _http_result : Test(6) {
 
     is $result->{decoded_content}, decode_utf8('<html><body><a href="./hoge">ほげ</a></body></html>');
     is $xpf->decoded_content,      decode_utf8('<html><body><a href="./hoge">ほげ</a></body></html>');
-
-    $xpf->clean;
 }
 
 sub _tree : Tests { local $TODO = 'TODO' }
@@ -121,8 +119,6 @@ sub _list : Test(5) {
     is $list->[1]->{node}->as_XML_compact,
         decode_utf8('<li><a href="./fuga">ふが</a></li>');
     is $list->[1]->{link}, decode_utf8('http://hogehoge.com/fuga');
-
-    $xpf->clean;
 }
 
 sub _search : Test(3) {
@@ -173,8 +169,6 @@ sub _scheme : Test(5) {
     is $list->[1]->{node}->as_XML_compact,
         decode_utf8('<li><a href="./fuga">ふが</a></li>');
     is $list->[1]->{link}, decode_utf8('http://hogehoge.com/fuga');
-
-    $xpf->clean;
 }
 
 __PACKAGE__->runtests;


### PR DESCRIPTION
Thanks to weak references, we can forget about HTML::TreeBuilder::delete ([HTML::TreeBuilder document](https://metacpan.org/pod/HTML::TreeBuilder#DESCRIPTION)). It eliminates the need for XPathFeed::(clean|DESTROY).

This change also stops `prove -l` from printing the warnings of "Use of uninitialized value $url ...". These warnings are caused by unintended initialization of $self->tree invoked by XPathFeed::clean.

By this change, perl without Scalar::Util::weaken will not be able to run XPathFeed. But Scalar::Util::weaken is bundled with perl since 5.8.0, so I believe this change will work in most environments.

(@onishi, what do you think about it?)
