### PR TITLE
HTTPS sites now working by not verifying their hostnames

### DIFF
--- a/lib/XPathFeed.pm
+++ b/lib/XPathFeed.pm
@@ -12,9 +12,11 @@ use HTML::Tagset;
 use HTML::TreeBuilder 5 -weak;
 use HTML::TreeBuilder::XPath;
 use HTTP::Request;
+use LWP::Protocol::https;
+use LWP::UserAgent 6;
 use Scalar::Util qw(blessed);
-use URI;
 use URI::Escape qw(uri_escape);
+use URI;
 use XML::RSS;
 
 our ($UserAgent, $Cache);

--- a/lib/XPathFeed.pm
+++ b/lib/XPathFeed.pm
@@ -99,6 +99,7 @@ sub uri {
 
 sub http_result {
     my $self = shift;
+    $ENV{PERL_LWP_SSL_VERIFY_HOSTNAME} = 0;
     $self->{http_result} ||= do {
         my $url    = $self->uri;
         my $cache  = $self->cache;


### PR DESCRIPTION
Fix for „No output for sites with https„ #4
