### PR TITLE
rediscloud:25 is no more available, now it should be `rediscloud:30`

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "XPathFeed",
   "description": "Generate RSS Feed from XPath",
-  "addons": ["rediscloud:25"],
+  "addons": ["rediscloud:30"],
   "success_url": "/",
   "env": {
     "BUILDPACK_URL": "https://github.com/pnu/heroku-buildpack-perl.git",


### PR DESCRIPTION
With `rediscloud:25`, We cannot build a new heroku app.
Current minimal plan is `rediscloud:30` : https://elements.heroku.com/addons/rediscloud#pricing

I deployed https://github.com/astj/xpathfeed/commit/b2305dd5b1a9e2f0dad726c5e1d430c0b7015b08 to heroku and it seems working.
